### PR TITLE
[hero] overflow hidden

### DIFF
--- a/src/components/styles/_layout.scss
+++ b/src/components/styles/_layout.scss
@@ -52,6 +52,7 @@ $background-color: #1C272B;
 
 
 div.container-fluid.hero {
+  overflow: hidden;
   padding: 0px 0px;
   // background-image: url(../../images/hero_BG-asset.svg);
 


### PR DESCRIPTION
This fixes a (minor) display issue w/ the hero image & overflow;

| before        | after           |
|:-------------:|:-------------:| 
| ![before-overflow-show](https://user-images.githubusercontent.com/56083362/77568350-b97e7680-6e85-11ea-9c6c-b4ecd0da8441.jpg)      | ![after-overflow-hidden](https://user-images.githubusercontent.com/56083362/77568386-c9965600-6e85-11ea-9401-1c30e8290a3e.jpg) |

