### PR TITLE
[lint] suppress warning about dangerouslySetInnerHTML

### DIFF
--- a/src/templates/blogTemplate.jsx
+++ b/src/templates/blogTemplate.jsx
@@ -4,6 +4,15 @@ import { graphql } from 'gatsby';
 // import SEO from '../components/seo';
 // import Layout from '../components/layout';
 
+/* eslint-disable */
+const blogContent = html => (
+  <div
+    className="blog-post-content"
+    dangerouslySetInnerHTML={{ __html: html }}
+  />
+);
+/* eslint-enable */
+
 export default function Template({
   data, // this prop will be injected by the GraphQL query below.
 }) {
@@ -14,10 +23,7 @@ export default function Template({
       <div className="blog-post">
         <h1>{frontmatter.title}</h1>
         <h2>{frontmatter.date}</h2>
-        <div
-          className="blog-post-content"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
+        {blogContent(html)}
       </div>
     </div>
   );


### PR DESCRIPTION
This suppresses the warning about `dangerouslySetInnerHTML` for blog content; that shows when running lint & opening PRs;

![dangerouslySetInnerHTML-warn](https://user-images.githubusercontent.com/56083362/77590386-d6797080-6eaa-11ea-99d6-2910ba026ded.jpg)
