### PR TITLE
[107] added code of conduct page

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of the Postman COVID-19 APIs project, we pledge to respect everyone who contributes.
+
+Please read our [Code of Conduct](https://www.postman.com/code-of-conduct "Postman's Code of Conduct") that covers all Postman communities.


### PR DESCRIPTION
This fixes #107:

— copied over the code of conduct page from Docs
— updated to say "Postman COVID-19 APIs"