### PR TITLE
add Japan and UK apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ New APIs that have emerged to specifically address the COVID-19 pandemic.
 - **Covid India API** ([Docs](https://documenter.getpostman.com/view/5310017/SzYW4LYY?version=latest)) - REST API to track Coronavirus cases in India on state level.
 - **COVID-19 Statistics API** ([Docs](https://documenter.getpostman.com/view/10724784/SzYXWz3x?version=latest)) - Based on public data by Johns Hopkins CSSE
 - **COVID19 -India- API(By Adhikansh Mittal)** ([Docs](https://documenter.getpostman.com/view/5665978/SzYaVdaW?version=latest)) -  The data is used from the official website of the Ministry of Health and Family Welfare of India.[Official website]
+- **UK Coronavirus Data API** ([Docs](https://documenter.getpostman.com/view/9215231/SzYZ2Jss?version=latest)) -  A live COVID-19 data scraper API that provides endpoints with history, and confirmed cases geo-location
+- **COVID-19 Japan Web API** ([Docs](https://documenter.getpostman.com/view/9215231/SzYaWe6h?version=latest)) -  Web API to get COVID-19(coronavirus) information of each prefecture in Japan
 
 ## ScrAPIs
 API possibilities opened up by scraping of COVID-19 related data and making available as APIs.

--- a/src/components/Microsite/Collections/Collection.data.json
+++ b/src/components/Microsite/Collections/Collection.data.json
@@ -167,6 +167,18 @@
       "urlDoc": "https://documenter.getpostman.com/view/8854915/SzYXVdyR?version=latest",
       "urlPost": "https://app.getpostman.com/run-collection/8854915-4e4a17a9-f372-4143-aff1-83f078be57a6-SzYXVdyR",
       "featured": true
+    },{
+      "title": "UK Coronavirus Data API",
+      "description": "A live COVID-19 data scraper API that provides endpoints with history, and confirmed cases geo-location",
+      "urlDoc": "https://documenter.getpostman.com/view/9215231/SzYZ2Jss?version=latest",
+      "urlPost": "https://app.getpostman.com/run-collection/5b048fc953bbeb2544ed",
+      "featured": false
+    },{
+      "title": "COVID-19 Japan Web API",
+      "description": "Web API to get COVID-19(coronavirus) information of each prefecture in Japan",
+      "urlDoc": "https://documenter.getpostman.com/view/9215231/SzYaWe6h?version=latest",
+      "urlPost": "https://app.getpostman.com/run-collection/5b048fc953bbeb2544ed",
+      "featured": false
     }
   ]
 }


### PR DESCRIPTION
Adding the two following templates with authorisation from the authors: 
https://github.com/ryo-ma/covid19-japan-web-api/issues/1
https://github.com/isjeffcom/coronvirusFigureUK/issues/7#event-3194281874