### PR TITLE
[MARKENG-479][c] node & npm versions; usage documentation; ensure versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 node_modules
+
+# Generated
+.nvmrc

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ This is a set of Postman collections that might help in the COVID-19 pandemic--c
 
 The website for this project can be found at: https://covid-19-apis.postman.com/
 
+## 🚀 Quick start
+
+Requires `nvm`
+
+```
+  git clone git@github.com:postmanlabs/covid-19-apis.git
+  cd covid-19-apis
+  npm run nvmrc
+  nvm use
+  npm install
+  npm run dev
+```
+
 ## Contribution guidelines
 
 We would love for you to contribute to the Postman COVID-19 API Resource Center! To contribute to this project, please read:

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
+    "nvmrc": "echo $(node -p -e 'require(\"./package\").engines.node.split(\">=\").join(\"\")') > .nvmrc",
     "test:lint": "node_modules/eslint/bin/eslint.js -c .eslintrc.js --ext .jsx --ext .js src/",
     "test:lint-fix": "node_modules/eslint/bin/eslint.js -c .eslintrc.js --ext .jsx --ext .js src/ --fix",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
@@ -62,5 +63,8 @@
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "engines": {
+    "node": "12.13.0"
   }
 }


### PR DESCRIPTION
**Ticket/Issue:**
MARKENG-479

**Root Cause**
When you use nvm to switch node versions, you’re also switching npm versions. If you switch to a new version of node w/ nvm, you will also switch to an unsupported version of npm that will generate a new package-lock file when you npm i.

**Solution Description**
_Branched from `develop`_, this adds documentation to the README file on how to use nvm to automatically switch to the correct version of node & npm when building & running the application.

![demo-ensure-node-npm-versions](https://user-images.githubusercontent.com/56083362/128937984-48b78b15-9aa9-4296-b07a-3f5b7f25a85a.gif)
