### PR TITLE
Markeng 401 decoupled postman analytics w/ custom load & client events

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -43,12 +43,12 @@ const prefetch = async () => {
       e.onload = cb;
       document.head.appendChild(e);
     }
-        
-    load('/${runtime.jq[1]}', function(){
-      load('/${runtime.pm[1]}', function(){
-        window.pm.scalp('My Category', 'My Action', 'My Label', 'My Property');
+    
+    if (!window.pm) {
+      load('/${runtime.jq[1]}', function(){
+        load('/${runtime.pm[1]}');
       });
-    });
+    }    
   `;
 
   fs.writeFile('bff.json', JSON.stringify({ script }), (err) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12107,8 +12107,7 @@
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "into-stream": {
       "version": "3.1.0",
@@ -17459,7 +17458,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -18844,7 +18842,6 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
       "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6210,6 +6210,12 @@
         }
       }
     },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "dev": true
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,14 +33,15 @@
     "react-cookie-consent": "^5.1.2",
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1",
+    "shelljs": "^0.8.4",
     "s3-deploy": "^1.4.0",
     "uuid": "^7.0.2"
   },
   "devDependencies": {
     "@postman/pm-tech": "^1.0.1",
+    "crypto": "^1.0.1",
     "jquery": "^3.6.0",
-    "prettier": "^1.19.1",
-    "shelljs": "^0.8.4"
+    "prettier": "^1.19.1"
   },
   "keywords": [
     "gatsby"

--- a/src/components/Microsite/Collections/Collection.jsx
+++ b/src/components/Microsite/Collections/Collection.jsx
@@ -10,30 +10,28 @@ const Collection = () => {
     }
   `);
 
-  return (
-    JSON.parse(data.collectionLinks.value).links.map((link) => {
-      const {
-        title, urlDoc, description,
-      } = link;
-      return (
-        <div key={Math.random()} className="row collection">
-          <div className="col-md-7">
-            <div className="row collection__meta">
-              <div className="col-12 collection__title">
-                {title}
-              </div>
-              <div className="col-12 collection__description">
-                {description}
-              </div>
-            </div>
-          </div>
-          <div className="col-md-5 collection_cta">
-            <a className="landing btn btn__secondary-light" href={urlDoc}>View Collections</a>
+  return JSON.parse(data.collectionLinks.value).links.map((link) => {
+    const { title, urlDoc, description } = link;
+    return (
+      <div key={Math.random()} className="row collection">
+        <div className="col-md-7">
+          <div className="row collection__meta">
+            <div className="col-12 collection__title">{title}</div>
+            <div className="col-12 collection__description">{description}</div>
           </div>
         </div>
-      );
-    })
-  );
+        <div className="col-md-5 collection_cta">
+          <a
+            className="landing btn btn__secondary-light"
+            href={urlDoc}
+            onClick={() => window.pm.scalp('pm-analytics', 'client-event', 'click', title)}
+          >
+            View Collections
+          </a>
+        </div>
+      </div>
+    );
+  });
 };
 
 export default Collection;

--- a/src/components/Microsite/layout.jsx
+++ b/src/components/Microsite/layout.jsx
@@ -15,7 +15,11 @@ import Footer from './Footer/Footer';
 import ReferrerCookie from '../ReferrerCookie';
 import './styles/_all.scss';
 
-const Layout = ({ children }) => (
+const delay = 1000;
+
+let throttle;
+
+const Layout = ({ children }) => {
   // const data = useStaticQuery(graphql`
   //   query SiteTitleQuery {
   //     site {
@@ -26,15 +30,28 @@ const Layout = ({ children }) => (
   //   }
   // `);
 
-  // return (
-  <div>
-    <Header />
-    <main>{children}</main>
-    <ReferrerCookie />
-    <Footer />
-  </div>
-);
-// };
+  if (typeof document === 'object') {
+    window.clearTimeout(throttle);
+
+    throttle = setTimeout(() => {
+      window.pm.scalp(
+        'pm-analytics',
+        'load',
+        'path',
+        document.location.pathname,
+      );
+    }, delay);
+  }
+
+  return (
+    <div>
+      <Header />
+      <main>{children}</main>
+      <ReferrerCookie />
+      <Footer />
+    </div>
+  );
+};
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/components/TestingSites/layout.jsx
+++ b/src/components/TestingSites/layout.jsx
@@ -13,14 +13,33 @@ import Footer from './footer';
 import ReferrerCookie from '../ReferrerCookie';
 import './styles/_allTesting.scss';
 
-const Layout = ({ children }) => (
-  <div>
-    <Header />
-    <main>{children}</main>
-    <ReferrerCookie />
-    <Footer />
-  </div>
-);
+const delay = 1000;
+
+let throttle;
+
+const Layout = ({ children }) => {
+  if (typeof document === 'object') {
+    window.clearTimeout(throttle);
+
+    throttle = setTimeout(() => {
+      window.pm.scalp(
+        'pm-analytics',
+        'load',
+        'path',
+        document.location.pathname,
+      );
+    }, delay);
+  }
+
+  return (
+    <div>
+      <Header />
+      <main>{children}</main>
+      <ReferrerCookie />
+      <Footer />
+    </div>
+  );
+};
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -16,7 +16,9 @@ const IndexPage = () => (
       <div className="container">
         <div className="row collection__header text-center">
           <div className="col-md-12">
-            <h2 className="h1">API Collections to Help in the COVID-19 Fight</h2>
+            <h2 className="h1">
+              API Collections to Help in the COVID-19 Fight
+            </h2>
           </div>
         </div>
         <div>
@@ -27,10 +29,21 @@ const IndexPage = () => (
             <p className="collection__end">
               To submit an API to add to the list, please email us at
               <br />
-              <span><a className="link-style" href="mailto:covid-19@postman.com"> COVID-19@postman.com</a></span>
+              <span>
+                <a className="link-style" href="mailto:covid-19@postman.com">
+                  {' '}
+                  COVID-19@postman.com
+                </a>
+              </span>
               or
               <span>
-                <a href="https://github.com/postman-toolboxes/covid-19/issues" className="link-style"> submit an issue on Github</a>
+                <a
+                  href="https://github.com/postman-toolboxes/covid-19/issues"
+                  className="link-style"
+                >
+                  {' '}
+                  submit an issue on Github
+                </a>
                 .
               </span>
             </p>
@@ -43,11 +56,23 @@ const IndexPage = () => (
         <div className="col-md-12">
           <h2> COVID-19 Testing Locations (Example Project)</h2>
           <p className="collection__end_p">
-            An example implementation showing how Google Sheets, Postman, and GitHub can be used to crowdsource public data.
+            An example implementation showing how Google Sheets, Postman, and
+            GitHub can be used to crowdsource public data.
           </p>
         </div>
         <div className="col-md-12 blurb_padding">
-          <Link className="btn btn__secondary-light" to="/covid-19-testing-locations/">See Reference Implementation</Link>
+          <Link
+            className="btn btn__secondary-light"
+            to="/covid-19-testing-locations/"
+            onClick={() => window.pm.scalp(
+              'pm-analytics',
+              'client-event',
+              'click',
+              'See Reference Implementation',
+            )}
+          >
+            See Reference Implementation
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Ticket/Issue:**
MARKENG-401

**What are the changes?**
_Branched from `develop`_, this decouples Postman Analytics w/ unique load & client events.

**Why make these changes?**
ATM, Postman Analytics mirrors third party analytics, _in the marketing web app specifically_; decoupling it & adding custom events to track will allow us to test further w/ the covid-19-apis web app.

example one (_load event_)
![demo-1-load-event](https://user-images.githubusercontent.com/56083362/130527235-e46a0b54-ab6f-4b5f-8ea6-d0e3304503de.gif)

example two (_client event_)
![demo-2-client-event](https://user-images.githubusercontent.com/56083362/130527272-6e7b88a3-56a6-45e0-8a56-a87267d04ed7.gif)

example three (_load event_)
![demo-3-loadevent](https://user-images.githubusercontent.com/56083362/130527319-4885782f-8558-4235-804c-f9e8e3e5b83e.gif)
