### PR TITLE
[MARKENG-401][c] updated pm-tech (sdk); reverted to allow valid 'beta' value for `env`

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -18,6 +18,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
         AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
         DIST_ID: ${{secrets.DEV_DIST_ID}}
+        GATSBY_NEWRELIC_ENV: dev
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
         npm install

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -18,6 +18,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
         AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
         DIST_ID: ${{secrets.PROD_DIST_ID}}
+        GATSBY_NEWRELIC_ENV: production
       run: |
         npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
         npm install

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "endOfLine": "lf",
   "semi": false,
-  "singleQuote": false,
+  "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1982,9 +1982,9 @@
       }
     },
     "@postman/pm-tech": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@postman/pm-tech/-/pm-tech-1.1.0.tgz",
-      "integrity": "sha512-nCZlrjaj6Y9O17Fz9o65M1sZXITRSzgxhrfR7R6X9wD4D0lVfVmTGXnaPtzcAhqCu0oJ/+Dq/aTnj6m9hvX/Wg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@postman/pm-tech/-/pm-tech-1.1.4.tgz",
+      "integrity": "sha512-QKDaK5Pck16cPxUIOKYgNZGDNYGYRXiIP/Csep/xUVD2ngBlwHk5zkrs7X3WqnHaxg8huP90UWKL/iZ6EEZdxw==",
       "dev": true,
       "requires": {
         "eslint": "^7.8.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "uuid": "^7.0.2"
   },
   "devDependencies": {
-    "@postman/pm-tech": "^1.1.0",
+    "@postman/pm-tech": "^1.1.4",
     "crypto": "^1.0.1",
     "jquery": "^3.6.0",
     "prettier": "^1.19.1"

--- a/src/components/Microsite/Collections/Collection.jsx
+++ b/src/components/Microsite/Collections/Collection.jsx
@@ -24,7 +24,11 @@ const Collection = () => {
           <a
             className="landing btn btn__secondary-light"
             href={urlDoc}
-            onClick={() => window.pm.scalp('pm-analytics', 'client-event', 'click', title)}
+            onClick={() => {
+              if (window.pm) {
+                window.pm.scalp('pm-analytics', 'client', 'click', title);
+              }
+            }}
           >
             View Collections
           </a>

--- a/src/components/Microsite/layout.jsx
+++ b/src/components/Microsite/layout.jsx
@@ -34,12 +34,14 @@ const Layout = ({ children }) => {
     window.clearTimeout(throttle);
 
     throttle = setTimeout(() => {
-      window.pm.scalp(
-        'pm-analytics',
-        'load',
-        'path',
-        document.location.pathname,
-      );
+      if (window.pm) {
+        window.pm.scalp(
+          'pm-analytics',
+          'load',
+          'path',
+          document.location.pathname,
+        );
+      }
     }, delay);
   }
 

--- a/src/components/TestingSites/layout.jsx
+++ b/src/components/TestingSites/layout.jsx
@@ -22,12 +22,14 @@ const Layout = ({ children }) => {
     window.clearTimeout(throttle);
 
     throttle = setTimeout(() => {
-      window.pm.scalp(
-        'pm-analytics',
-        'load',
-        'path',
-        document.location.pathname,
-      );
+      if (window.pm) {
+        window.pm.scalp(
+          'pm-analytics',
+          'load',
+          'path',
+          document.location.pathname,
+        );
+      }
     }, delay);
   }
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -64,12 +64,16 @@ const IndexPage = () => (
           <Link
             className="btn btn__secondary-light"
             to="/covid-19-testing-locations/"
-            onClick={() => window.pm.scalp(
-              'pm-analytics',
-              'client-event',
-              'click',
-              'See Reference Implementation',
-            )}
+            onClick={() => {
+              if (window.pm) {
+                window.pm.scalp(
+                  'pm-analytics',
+                  'client',
+                  'click',
+                  'See Reference Implementation',
+                );
+              }
+            }}
           >
             See Reference Implementation
           </Link>


### PR DESCRIPTION
**Ticket/Issue:**
MARKENG-401

**What are the changes?**
_Branched from `develop`_, this updates pm-tech (sdk); reverted to allow valid ‘beta’ value for `env`.
_also, included:
 - GATSBY_NEWRELIC_ENV var in github workflows
 - added safe guard for pm.scalp calls_

**Why make these changes?**
The validation tool was updated to allow for “env” values set to “beta”, for SCALP validation.

<img width="510" alt="validated-beta-event" src="https://user-images.githubusercontent.com/56083362/130660798-12510635-4cd0-4129-a274-666dcd0cae41.png">
