### PR TITLE
[MARKENG-401] bump pm-tech to v1.1.8 for referrer value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = off
+
+[*.txt]
+indent_style = tab
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,0 +1,32 @@
+5.7.0:
+  date: 2021-09-29
+  items:
+  - '[MARKENG-401] bump pm-tech to v1.1.8 for referrer value'
+5.6.0:
+  date: 2021-09-08
+  items:
+  - '[MARKENG-401] bump pm-tech (^1.1.6)'
+  - '[MARKENG-401] bump pm-tech (^1.1.5)'
+5.5.0:
+  date: 2021-08-24
+  items:
+  - '[MARKENG-401] reconfigure github actions & newrelic'
+  - '[MARKENG-401] updated pm-tech (sdk); reverted to allow valid "beta" value for `env`'
+  - '[MARKENG-401] set SCALP property to covid-19-apis'
+5.4.0:
+  date: 2021-08-23
+  items:
+  - '[MARKENG-401] hash runtime utility names'
+  - '[MARKENG-401] decoupled Postman Analytics'
+5.3.0:
+  date: 2021-08-19
+  items:
+  - '[MARKENG-401] consume (private) pm-tech package for covid-19-api'
+5.2.0:
+  date: 2021-08-18
+  items:
+  - '[MARKENG-400] added NewRelic for monitoring as we test the PostmanAnalytic SDK'
+5.1.0:
+  date: 2021-08-11
+  items:
+  - '[MARKENG-479] node & npm versions; usage documentation to ensure for covid-19-apis web app'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "uuid": "^7.0.2"
   },
   "devDependencies": {
-    "@postman/pm-tech": "^1.1.6",
+    "@postman/pm-tech": "1.1.8",
     "crypto": "^1.0.1",
     "jquery": "^3.6.0",
     "prettier": "^1.19.1"


### PR DESCRIPTION
**What are the changes?**
_Branched from `develop`_, this bumps the pm-tech SDK to v1.1.8, (_for referrer value_).
*Also adds `.editorconfig` & `CHANGELOG.yml` files

**Why make these changes?**
The SDK has been updated to include the referrer value, if it is available. The change log file will offer a human readable file for knowing what changes. The `.editorconfig` file will do several things, including keeping white-spaces in code under control.

_*no visuals_