### PR TITLE
Update Node version to 14.17.1. LTS; remove carets in packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6519,9 +6519,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "moment": "2.29.3",
     "node-fetch": "2.6.7",
     "node-sass": "4.14.1",
-    "path-browserify": "^1.0.1",
+    "path-browserify": "1.0.1",
     "prop-types": "15.8.1",
     "react": "18.1.0",
     "react-dom": "18.1.0",
@@ -40,7 +40,7 @@
     "crypto": "1.0.1",
     "eslint": "8.14.0",
     "eslint-config-airbnb": "19.0.4",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.29.4",
     "jquery": "3.6.0",
     "prettier": "2.6.2"
@@ -72,6 +72,6 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "engines": {
-    "node": "14.15.0"
+    "node": "14.17.1"
   }
 }


### PR DESCRIPTION
* update Node to v14.17.1 LTS
* removed carets `^` from package file to stabilize them, and reduce package-lock volatility for contributors.
* expect no changes to UI, build, and deployment
