### PR TITLE
[MARKENG-1638] disable gatsby-plugin-google-analytics & roll our own for GTM/GA

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -11,9 +11,12 @@ const runtime = {
 
 const prefetch = async () => {
   let pmTech = '';
+  let pmTechVersion = '';
 
   if (process.env.PM_TECH) {
     pmTech = await fetchPmTech();
+
+    pmTechVersion = pmTech.split('ns.version="').pop().split('"').shift();
 
     pmTech = base64.encode(pmTech);
 
@@ -42,21 +45,50 @@ const prefetch = async () => {
 
   const script = (process.env.PM_TECH
       && `
+      var propertyName = 'covid-19-apis';
       var delay = 500;
       var scr = document.createElement('script');
       var throttle;
+      var int;
+      scr.setAttribute('id', 'pmTechSDK');
       scr.innerText = atob('${pmTech}');
       if (!window.pm) {
         throttle = setTimeout(function(){
           document.head.appendChild(scr);
+          window.pm.log('attached pmTechSDK: ' + '${pmTechVersion}');
           setTimeout(function(){
             if (window.pm) {
               window.pm.setScalp({
-                property: 'covid-19-apis'
+                property: propertyName
               });
               window.pm.trackClicks();
+              var dnt = (parseInt(navigator.doNotTrack) === 1 || parseInt(window.doNotTrack) === 1 || parseInt(navigator.msDoNotTrack) === 1 || navigator.doNotTrack === "yes");
+              window.pm.log('navigator.doNotTrack: ' + dnt);
+              if(!dnt) {
+                var id = 'gtm';
+                var sitename = 'covid-19-apis.postman.com';
+                var UACode = 'UA-43979731-18';
+                if (!document.getElementById(id)) {
+                  var gtm = document.createElement('script');
+                  gtm.setAttribute('id', id);
+                  gtm.src = 'https://www.googletagmanager.com/gtag/js?id=' + UACode;
+
+                  gtm.onload = function(){
+                    window.dataLayer = window.dataLayer || [];
+                    function gtag(){dataLayer.push(arguments);}
+                    gtag('js', new Date());
+                    gtag('config', UACode);
+                    window.pm.ga('create', UACode, sitename);
+                    window.pm.log('initialized GA: ' + sitename);
+                    clearTimeout(throttle);
+                  };
+                  document.head.appendChild(gtm);
+                  window.pm.log('attached googletagmanager: ' + UACode);
+                }
+              } else {
+                clearTimeout(throttle);
+              }
             }
-            clearTimeout(throttle);
           }, delay);
         }, delay);
       }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,19 +12,6 @@ module.exports = {
     siteUrl: 'https://covid-19-apis.postman.com/',
   },
   plugins: [
-    {
-      resolve: 'gatsby-plugin-google-analytics',
-      options: {
-        // The property ID; the tracking code won't be generated without it
-        trackingId: 'UA-43979731-18',
-        // Defines where to place the tracking script - `true` in the head and `false` in the body
-        head: true,
-        // Setting this parameter is also optional
-        respectDNT: true,
-        alwaysSendReferrer: true,
-        forceSSL: true,
-      },
-    },
     'gatsby-plugin-react-helmet',
     {
       resolve: 'gatsby-source-filesystem',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8031,16 +8031,6 @@
         "@babel/runtime": "^7.11.2"
       }
     },
-    "gatsby-plugin-google-analytics": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-4.17.0.tgz",
-      "integrity": "sha512-Jv9h2wpVNCvALZWwakwbpD/GZ+pYzzxVATwarUm5DICj+iXx2P2Q86PzblEmxGXpRpSHdnrrN8ntzYxpm13TjQ==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "minimatch": "3.0.4",
-        "web-vitals": "^1.1.2"
-      }
-    },
     "gatsby-plugin-manifest": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-4.17.0.tgz",
@@ -15814,11 +15804,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
-    },
-    "web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "gatsby": "4.17.1",
     "gatsby-plugin-anchor-links": "1.2.1",
     "gatsby-plugin-gdpr-cookies": "2.0.9",
-    "gatsby-plugin-google-analytics": "4.17.0",
     "gatsby-plugin-manifest": "4.17.0",
     "gatsby-plugin-meta-redirect": "1.1.1",
     "gatsby-plugin-newrelic": "2.2.2",


### PR DESCRIPTION
**What are the changes?**
_Branched from `develop`_, this disables `gatsby-plugin-google-analytics` & rolls our own GTM script insertion w/o plugins.

**Why make these changes?**
By rolling our own, we have finite control of how GTM & GA behaves. This aims to serve as a potential model for our other web apps