### PR TITLE
[MARKENG-2419][c] pmt.log gtag

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -47,6 +47,7 @@ setTimeout(function(){
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', UACode);
+          window.pmt('log', ['gtag: ${UACode}']);
           window.pmt('ga', ['${UACode}', sitename]);
           window.pmt('log', ['initialized GA: ' + sitename + ' (' + '${UACode}' + ')']);
         };


### PR DESCRIPTION
### What are the changes?
 Branched from `develop`, this uses pmt.logs the config gtag for the web app.
 
### Why make these changes? 
   Doing so allows us to quickly see what gtag is set for the web app.

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/56083362/235006243-68e7b70f-bbb7-475d-979d-6e6f90323336.png">
