### PR TITLE
[MARKENG-3051][c] update `axios` from 1.5.1 to 1.6.3 (latest ATM)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3622,9 +3622,9 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
     },
     "axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
+      "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Postman",
   "dependencies": {
     "aether-marketing": "1.27.10",
-    "axios": "1.5.1",
+    "axios": "1.6.3",
     "base-64": "1.0.0",
     "bootstrap": "4.5.0",
     "dotenv": "8.2.0",


### PR DESCRIPTION
### What are the changes?
_Branched from `develop`_, this updates `axios` from 1.5.1 to 1.6.3 (latest ATM)

### Why make these changes?
To ensue possible vulnerabilities _(that we can control)_ are not reported. Unfortunately, we can’t do anything to affect the reported `gatsby` vulnerability itself;

<img width="1728" alt="Pasted Graphic 16" src="https://github.com/postmanlabs/covid-19-apis/assets/56083362/3d79d52a-cacd-4043-af23-a16ebf4bc96f">

